### PR TITLE
Add the parse tree visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2084,12 +2084,6 @@
         "@testing-library/dom": "^7.0.3"
       }
     },
-    "@tsconfig/svelte": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-1.0.3.tgz",
-      "integrity": "sha512-rk+BuV7fNAE33bywtzgNCbPSVEITOeR9zFPeHHJaD9lTcmjZQQRe5fOGJtsdyG3JJKoAZ4JSYVbll4CvWhC3sA==",
-      "dev": true
-    },
     "@types/aria-query": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
@@ -8711,6 +8705,11 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "svelte-tree": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/svelte-tree/-/svelte-tree-0.7.0.tgz",
+      "integrity": "sha512-22YEdqHvqQ+2OJzFqBznn6QgvoT0DGQPU04Wij5PilWDs4bPpQTbKSaSCWVBwdeNxnfk8ZB7H9J/2s2TNCv+lw=="
+    },
     "svelte2tsx": {
       "version": "0.1.64",
       "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.1.64.tgz",
@@ -8879,12 +8878,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
-    },
-    "tslib": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
-      "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==",
-      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "svelte-preprocess": "^4.0.8"
   },
   "dependencies": {
-    "codemirror": "^5.49.2"
+    "codemirror": "^5.49.2",
+    "svelte-tree": "^0.7.0"
   }
 }

--- a/src/core/ebnf/src/checker/mod.rs
+++ b/src/core/ebnf/src/checker/mod.rs
@@ -1,13 +1,15 @@
 pub mod error;
+pub mod node;
 
 use super::parser::{Expression, Grammar};
 use super::span::{Span, Spanned, Spanning};
+use node::Node;
 
 fn check_expr<'a>(
     input: &'a str,
     expression: &'a Expression,
     grammar: &'a Spanned<Grammar>,
-) -> Result<(&'a str, String), ()> {
+) -> Result<(&'a str, String, Option<Vec<Node>>), ()> {
     match &expression {
         Expression::Alternative {
             first: box Spanned { node: first, .. },
@@ -15,11 +17,11 @@ fn check_expr<'a>(
             rest,
         } => {
             match check_expr(input, first, grammar) {
-                Ok((rest, output)) => return Ok((rest, output)),
+                Ok((rest, output, node)) => return Ok((rest, output, node)),
                 Err(()) => {}
             }
             match check_expr(input, second, grammar) {
-                Ok((rest, output)) => return Ok((rest, output)),
+                Ok((rest, output, node)) => return Ok((rest, output, node)),
                 Err(()) => {}
             }
             for Spanned {
@@ -27,7 +29,7 @@ fn check_expr<'a>(
             } in rest.iter()
             {
                 match check_expr(input, expression, grammar) {
-                    Ok((rest, output)) => return Ok((rest, output)),
+                    Ok((rest, output, node)) => return Ok((rest, output, node)),
                     Err(()) => {}
                 }
             }
@@ -40,38 +42,52 @@ fn check_expr<'a>(
         } => {
             let mut input = input;
             let mut output = String::new();
-            let (inp, output_first) = check_expr(input, first, grammar)?;
+            let mut nodes = Vec::new();
+            let (inp, output_first, node_first) = check_expr(input, first, grammar)?;
             input = inp;
             output.push_str(&output_first);
-            let (inp, output_second) = check_expr(input, second, grammar)?;
+            if let Some(n) = node_first {
+                nodes.extend(n);
+            }
+            let (inp, output_second, node_second) = check_expr(input, second, grammar)?;
             input = inp;
             output.push_str(&output_second);
+            if let Some(n) = node_second {
+                nodes.extend(n);
+            }
             for Spanned {
                 node: expression, ..
             } in rest.iter()
             {
-                let (inp, output_expr) = check_expr(input, expression, grammar)?;
+                let (inp, output_expr, node_expr) = check_expr(input, expression, grammar)?;
                 input = inp;
                 output.push_str(&output_expr);
+                if let Some(n) = node_expr {
+                    nodes.extend(n);
+                }
             }
-            Ok((input, output))
+            Ok((input, output, Some(nodes)))
         }
         Expression::Optional(box Spanned { node: inner, .. }) => {
             match check_expr(input, inner, grammar) {
-                Ok((rest, output)) => Ok((rest, output)),
-                Err(()) => Ok((input, String::new())),
+                Ok((rest, output, nodes)) => Ok((rest, output, nodes)),
+                Err(()) => Ok((input, String::new(), None)),
             }
         }
         Expression::Repeated(box Spanned { node: inner, .. }) => {
             let mut input = input;
             let mut output = String::new();
+            let mut nodes = Vec::new();
             loop {
                 match check_expr(input, inner, grammar) {
-                    Ok((rest, out)) => {
+                    Ok((rest, out, node_expr)) => {
                         input = rest;
                         output.push_str(&out);
+                        if let Some(n) = node_expr {
+                            nodes.extend(n);
+                        }
                     }
-                    Err(()) => return Ok((input, output)),
+                    Err(()) => return Ok((input, output, Some(nodes))),
                 }
             }
         }
@@ -81,16 +97,20 @@ fn check_expr<'a>(
         } => {
             let mut input = input;
             let mut output = String::new();
+            let mut nodes = Vec::new();
             for _ in 0..*count {
                 match check_expr(input, primary, grammar) {
-                    Ok((rest, out)) => {
+                    Ok((rest, out, node_expr)) => {
                         input = rest;
                         output.push_str(&out);
+                        if let Some(n) = node_expr {
+                            nodes.extend(n);
+                        }
                     }
                     Err(()) => return Err(()),
                 }
             }
-            Ok((input, output))
+            Ok((input, output, Some(nodes)))
         }
         Expression::Exception {
             subject: box Spanned { node: subject, .. },
@@ -98,29 +118,26 @@ fn check_expr<'a>(
                 node: restriction, ..
             },
         } => {
-            let (input, read_chars) = check_expr(input, subject, grammar)?;
+            let (input, read_chars, node) = check_expr(input, subject, grammar)?;
             match check_expr(&read_chars, restriction, grammar) {
-                Ok((_, matched_chars)) => {
-                    if matched_chars == read_chars {
-                        Err(())
-                    } else {
-                        Ok((input, read_chars))
-                    }
-                }
-                Err(()) => Ok((input, read_chars)),
+                Ok((_, matched_chars, _)) if matched_chars == read_chars => Err(()),
+                _ => Ok((input, read_chars, node)),
             }
         }
-        Expression::Nonterminal(identifier) => check_prod(input, grammar, identifier),
+        Expression::Nonterminal(identifier) => {
+            let (rest, out, node) = check_prod(input, grammar, identifier)?;
+            return Ok((rest, out, Some(vec![node])));
+        },
         Expression::Terminal(content) => {
             if input.starts_with(content) {
                 let len = content.len();
-                Ok((&input[len..], content.clone()))
+                Ok((&input[len..], content.clone(), Some(vec![Node::Terminal(content.clone())])))
             } else {
                 Err(())
             }
         }
         Expression::Special(_) => Err(()),
-        Expression::Empty => Ok((input, String::new())),
+        Expression::Empty => Ok((input, String::new(), None)),
     }
 }
 
@@ -128,14 +145,15 @@ pub(super) fn check_prod<'a>(
     input: &'a str,
     grammar: &'a Spanned<Grammar>,
     initial_rule: &'a str,
-) -> Result<(&'a str, String), ()> {
+) -> Result<(&'a str, String, Node), ()> {
     let productions = &grammar.node.productions;
     for production in productions.iter() {
         let production = &production.node;
         let lhs = &production.lhs.node;
         let rhs = &production.rhs.node;
         if initial_rule == lhs {
-            return check_expr(input, rhs, grammar);
+            let (rest, out, nodes) = check_expr(input, rhs, grammar)?;
+            return Ok((rest, out, Node::Nonterminal(lhs.clone(), nodes.unwrap_or(Vec::new()))));
         }
     }
     unreachable!()
@@ -145,9 +163,9 @@ pub(super) fn check<'a>(
     input: &'a str,
     grammar: &'a Spanned<Grammar>,
     initial_rule: &'a str,
-) -> bool {
+) -> Option<Node> {
     match check_prod(input, grammar, initial_rule) {
-        Ok((input, _)) => input.is_empty(),
-        Err(()) => false,
+        Ok((input, _, node)) if input.is_empty() => Some(node),
+        _ => None,
     }
 }

--- a/src/core/ebnf/src/checker/node.rs
+++ b/src/core/ebnf/src/checker/node.rs
@@ -1,0 +1,5 @@
+#[derive(Clone)]
+pub enum Node {
+    Nonterminal(String, Vec<Node>),
+    Terminal(String),
+}

--- a/src/core/ebnf/src/lib.rs
+++ b/src/core/ebnf/src/lib.rs
@@ -2,7 +2,7 @@
 
 use error::Error;
 
-mod checker;
+pub mod checker;
 pub mod error;
 mod lexer;
 mod parser;
@@ -11,6 +11,7 @@ mod span;
 
 use parser::Grammar;
 use span::Spanned;
+use checker::node::Node;
 
 pub struct Parser {
     ast: Spanned<Grammar>,
@@ -45,6 +46,6 @@ pub fn get_production_rules(
         .collect()
 }
 
-pub fn check(input: &str, parser: &Parser, initial_rule: &str) -> bool {
+pub fn check(input: &str, parser: &Parser, initial_rule: &str) -> Option<Node> {
     checker::check(input, &parser.ast, initial_rule)
 }

--- a/src/core/ebnf/src/preprocessor/mod.rs
+++ b/src/core/ebnf/src/preprocessor/mod.rs
@@ -106,18 +106,6 @@ fn check_expr(
             second: box second,
             rest,
         } => {
-            // if !is_failing(first, rules, &mut vec![trace.last().unwrap().clone()]) {
-            //     return check_expr(first, rules, trace);
-            // } else if !is_failing(second, rules, &mut vec![trace.last().unwrap().clone()]) {
-            //     return check_expr(second, rules, trace);
-            // } else {
-            //     for expression in rest[..rest.len() - 1].iter() {
-            //         if !is_failing(expression, rules, &mut vec![trace.last().unwrap().clone()]) {
-            //             return check_expr(expression, rules, trace);
-            //         }
-            //     }
-            //     return check_expr(&rest.last().unwrap(), rules, trace);
-            // }
             if !is_failing(first, rules, &mut vec![trace.last().unwrap().clone()]) {
                 return check_expr(first, rules, trace);
             }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,1 +1,31 @@
 pub mod error;
+
+use super::ebnf::checker::node::Node;
+use js_sys::{Array, Object, Reflect};
+use wasm_bindgen::prelude::*;
+
+#[allow(unused_unsafe)]
+pub fn tree(node: Node) -> Object {
+    match node {
+        Node::Terminal(string) => {
+            let obj = Object::new();
+            unsafe {
+                Reflect::set(&obj, &"name".into(), &string.into())
+                    .unwrap();
+            }
+            return obj;
+        },
+        Node::Nonterminal(name, nodes) => {
+            let obj = Object::new();
+            let children: Vec<Object> = nodes.iter().cloned().map(tree).collect();
+            let children_array: Array = children.into_iter().map(JsValue::from).collect();
+            unsafe {
+                Reflect::set(&obj, &"name".into(), &name.into())
+                    .unwrap();
+                Reflect::set(&obj, &"children".into(), &children_array.into())
+                        .unwrap();
+            }
+            return obj;
+        }
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,7 +10,7 @@ pub fn tree(node: Node) -> Object {
         Node::Terminal(string) => {
             let obj = Object::new();
             unsafe {
-                Reflect::set(&obj, &"name".into(), &string.into())
+                Reflect::set(&obj, &"name".into(), &format!("\"{}\"", string).into())
                     .unwrap();
             }
             return obj;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 use crate::core::error::Error;
 use ebnf_parser_parser as ebnf;
-use js_sys::Array;
+use js_sys::{Array, Object};
 use wasm_bindgen::prelude::*;
+use crate::core::tree;
 
 mod core;
 
@@ -34,8 +35,8 @@ impl EbnfParserParser {
             .collect()
     }
 
-    pub fn check(&self, input: &str, initial_rule: &str) -> bool {
-        ebnf::check(input, &self.parser, initial_rule)
+    pub fn check(&self, input: &str, initial_rule: &str) -> Option<Object> {
+        ebnf::check(input, &self.parser, initial_rule).map(tree)
     }
 }
 

--- a/src/site/editor/Editor.svelte
+++ b/src/site/editor/Editor.svelte
@@ -49,6 +49,7 @@
     function check(input) {
         if (parser) {
             output = parser.check(input, initialProductionRule);
+            console.log(output);
         }
     }
 
@@ -115,11 +116,12 @@
             on:change="{handleCheckChange}"
             mode="text"
         />
+        {#if output != null}
+            <Tree tree={[output]} let:node>
+                <div class="output">{node.name}</div>
+            </Tree>
+        {:else}
+            <p class="output">failure</p>
+        {/if}
     </div>
-    {#if output != null}
-        <Tree tree={[output]} let:node>
-            <div class="output">{node.name}</div>
-        </Tree>
-        <!-- <p class="output">{"> " + output}</p> -->
-    {/if}
 </div>

--- a/src/site/editor/Editor.svelte
+++ b/src/site/editor/Editor.svelte
@@ -1,5 +1,6 @@
 <script>
     import CodeMirror from "./codemirror/CodeMirror.svelte";
+    import Tree from "svelte-tree";
 
     export let core;
     let parseEditor;
@@ -7,12 +8,12 @@
     let parser;
     let productionRules = [];
     let initialProductionRule;
-    let output = "";
+    let output = null;
     let error;
 
     async function handleParseChange(event) {
         parser = undefined;
-        output = "";
+        output = null;
         try {
             parser = new core.EbnfParserParser(event.detail.value);
             productionRules = parser.productionRules;
@@ -47,7 +48,7 @@
 
     function check(input) {
         if (parser) {
-            output = parser.check(input, initialProductionRule) ? "success" : "failure";
+            output = parser.check(input, initialProductionRule);
         }
     }
 
@@ -115,7 +116,10 @@
             mode="text"
         />
     </div>
-    {#if output != ""}
-        <p class="output">{"> " + output}</p>
+    {#if output != null}
+        <Tree tree={[output]} let:node>
+            <div class="output">{node.name}</div>
+        </Tree>
+        <!-- <p class="output">{"> " + output}</p> -->
     {/if}
 </div>


### PR DESCRIPTION
## Description

These changes are related to the issue #11. The `checker` has been refactored to return the parse tree of the provided input. The parse tree encoded in the `Node` type is then converted to a JavaScript object to be displayed in the front-end with the use of the `svelte-tree` npm package. The resulting tree is interactable and, to some extent, styleable.